### PR TITLE
feature send to mackerel

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,18 +8,6 @@
   version = "v0.3.0"
 
 [[projects]]
-  name = "github.com/Songmu/timeout"
-  packages = ["."]
-  revision = "99732a2d3ea37f1111245d34bc520b25b83ecb65"
-  version = "v0.3.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/Songmu/wrapcommander"
-  packages = ["."]
-  revision = "c228fd70413bba4c4b70d0bd78d4665dc6ec252b"
-
-[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -62,12 +50,6 @@
   revision = "0b12d6b5"
 
 [[projects]]
-  name = "github.com/k0kubun/pp"
-  packages = ["."]
-  revision = "027a6d1765d673d337e687394dbe780dd64e2a1e"
-  version = "v2.3.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/kayac/go-config"
   packages = ["."]
@@ -75,49 +57,9 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/mackerelio/go-osstat"
-  packages = [
-    "loadavg",
-    "network"
-  ]
-  revision = "192e3c5eacaf0298c586d075196af1570c912e2f"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mackerelio/golib"
-  packages = ["logging"]
-  revision = "295ea2626d02a5d78c2ad6c4148a77ab68540b79"
-
-[[projects]]
-  name = "github.com/mackerelio/mackerel-agent"
-  packages = [
-    "checks",
-    "cmdutil",
-    "config",
-    "mackerel",
-    "metrics",
-    "util"
-  ]
-  revision = "bf64e4de030415c1574b0babf89186e18e8edec0"
-  version = "v0.53.0"
-
-[[projects]]
-  branch = "master"
   name = "github.com/mackerelio/mackerel-client-go"
   packages = ["."]
   revision = "f8d2a23df607c93fe287c259576a408141fbf116"
-
-[[projects]]
-  name = "github.com/mattn/go-colorable"
-  packages = ["."]
-  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
-  version = "v0.0.9"
-
-[[projects]]
-  name = "github.com/mattn/go-isatty"
-  packages = ["."]
-  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
-  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/mattn/go-shellwords"
@@ -132,12 +74,6 @@
   version = "v0.8.0"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "01acb38716e021ed1fc03a602bdb5838e1358c5e"
-
-[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -146,6 +82,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7fe7954eee83688632bd4b4bb3926e7863ce1fae4f0cb9554b88f998c3f249ef"
+  inputs-digest = "fc26534f47cd1eef555d0bc9f2bf7b0a7bc14566f7da169172076bbf813b18da"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,8 +8,45 @@
   version = "v0.3.0"
 
 [[projects]]
+  name = "github.com/Songmu/timeout"
+  packages = ["."]
+  revision = "99732a2d3ea37f1111245d34bc520b25b83ecb65"
+  version = "v0.3.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/Songmu/wrapcommander"
+  packages = ["."]
+  revision = "c228fd70413bba4c4b70d0bd78d4665dc6ec252b"
+
+[[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/cloudwatch","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/cloudwatch",
+    "service/sts"
+  ]
   revision = "388e6676807f5968ad5eaaec0c70002f80c20b84"
   version = "v1.12.39"
 
@@ -25,10 +62,62 @@
   revision = "0b12d6b5"
 
 [[projects]]
+  name = "github.com/k0kubun/pp"
+  packages = ["."]
+  revision = "027a6d1765d673d337e687394dbe780dd64e2a1e"
+  version = "v2.3.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/kayac/go-config"
   packages = ["."]
   revision = "762bc25448755c6ccfe0265ed3013c9d507569c5"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mackerelio/go-osstat"
+  packages = [
+    "loadavg",
+    "network"
+  ]
+  revision = "192e3c5eacaf0298c586d075196af1570c912e2f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mackerelio/golib"
+  packages = ["logging"]
+  revision = "295ea2626d02a5d78c2ad6c4148a77ab68540b79"
+
+[[projects]]
+  name = "github.com/mackerelio/mackerel-agent"
+  packages = [
+    "checks",
+    "cmdutil",
+    "config",
+    "mackerel",
+    "metrics",
+    "util"
+  ]
+  revision = "bf64e4de030415c1574b0babf89186e18e8edec0"
+  version = "v0.53.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mackerelio/mackerel-client-go"
+  packages = ["."]
+  revision = "f8d2a23df607c93fe287c259576a408141fbf116"
+
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/mattn/go-shellwords"
@@ -43,6 +132,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "01acb38716e021ed1fc03a602bdb5838e1358c5e"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -51,6 +146,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f31b2673c855749f943621f0c1d1c2d9c39a0e12443393b5ffe2d86a9e8fded0"
+  inputs-digest = "7fe7954eee83688632bd4b4bb3926e7863ce1fae4f0cb9554b88f998c3f249ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config.go
+++ b/config.go
@@ -92,12 +92,12 @@ func (pc *PluginConfig) NewMetricPlugin(id string, ch chan *cloudwatch.PutMetric
 	if pc.Command == "" {
 		return nil, errors.New("command required")
 	}
-	driver := CloudWatchDriver{Ch: ch}
+	dimensions := [][]*cloudwatch.Dimension{}
 	for _, d := range pc.Dimensions {
 		if ds, err := d.CloudWatchDimensions(); err != nil {
 			return nil, err
 		} else {
-			driver.Dimensions = append(driver.Dimensions, ds)
+			dimensions = append(dimensions, ds)
 		}
 	}
 	mp := &MetricPlugin{
@@ -105,7 +105,7 @@ func (pc *PluginConfig) NewMetricPlugin(id string, ch chan *cloudwatch.PutMetric
 		Command:      pc.Command,
 		Timeout:      pc.Timeout.Duration,
 		Interval:     pc.Interval.Duration,
-		PluginDriver: &driver,
+		PluginDriver: &CloudWatchDriver{Dimensions: dimensions, Ch: ch},
 	}
 	if mp.Timeout == 0 {
 		mp.Timeout = DefaultCommandTimeout

--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ func (pc *PluginConfig) NewMackerelMetricPlugin(conf *Config, id string) (*Metri
 		Interval:         pc.Interval.Duration,
 		HostID:           conf.hostID,
 		CustomIdentifier: pc.CustomIdentifier,
-		MetricParser:     mackerelMetricParser,
+		MetricParser:     mackerelMetlicLineParser,
 	}
 	if mp.Timeout == 0 {
 		mp.Timeout = DefaultCommandTimeout

--- a/config.go
+++ b/config.go
@@ -94,10 +94,11 @@ func (pc *PluginConfig) NewMetricPlugin(id string) (*MetricPlugin, error) {
 		return nil, errors.New("command required")
 	}
 	mp := &MetricPlugin{
-		ID:       fmt.Sprintf("plugin.metrics.%s", id),
-		Command:  pc.Command,
-		Timeout:  pc.Timeout.Duration,
-		Interval: pc.Interval.Duration,
+		ID:           fmt.Sprintf("plugin.metrics.%s", id),
+		Command:      pc.Command,
+		Timeout:      pc.Timeout.Duration,
+		Interval:     pc.Interval.Duration,
+		MetricParser: metricLineParser,
 	}
 	for _, d := range pc.Dimensions {
 		if ds, err := d.CloudWatchDimensions(); err != nil {
@@ -126,6 +127,7 @@ func (pc *PluginConfig) NewMackerelMetricPlugin(conf *Config, id string) (*Metri
 		Interval:         pc.Interval.Duration,
 		HostID:           conf.hostID,
 		CustomIdentifier: pc.CustomIdentifier,
+		MetricParser:     mackerelMetricParser,
 	}
 	if mp.Timeout == 0 {
 		mp.Timeout = DefaultCommandTimeout

--- a/config.go
+++ b/config.go
@@ -58,7 +58,7 @@ func (d *Dimension) CloudWatchDimensions() ([]*cloudwatch.Dimension, error) {
 	return ds, nil
 }
 
-func (pc *PluginConfig) NewCloudWatchDriver(id string) (*CloudWatchMetricPlugin, error) {
+func (pc *PluginConfig) NewCloudWatchMetricPlugin(id string) (*CloudWatchMetricPlugin, error) {
 	if pc.Command == "" {
 		return nil, errors.New("command required")
 	}
@@ -88,7 +88,7 @@ func (pc *PluginConfig) NewCloudWatchDriver(id string) (*CloudWatchMetricPlugin,
 	return pd, nil
 }
 
-func (pc *PluginConfig) NewMackerelDriver(id string) (*MackerelMetricPlugin, error) {
+func (pc *PluginConfig) NewMackerelMetricPlugin(id string) (*MackerelMetricPlugin, error) {
 	if pc.Command == "" {
 		return nil, errors.New("command required")
 	}
@@ -162,13 +162,13 @@ func LoadConfig(path string) (*Config, error) {
 		case "metrics":
 			for id, pc := range value {
 				if pc.Destination == "mackerel" {
-					d, err := pc.NewMackerelDriver(id)
+					d, err := pc.NewMackerelMetricPlugin(id)
 					if err != nil {
 						return nil, err
 					}
 					c.MackerelMetricPlugins[id] = d
 				} else {
-					d, err := pc.NewCloudWatchDriver(id)
+					d, err := pc.NewCloudWatchMetricPlugin(id)
 					if err != nil {
 						return nil, err
 					}

--- a/config.go
+++ b/config.go
@@ -121,7 +121,7 @@ func (pc *PluginConfig) NewMackerelMetricPlugin(conf *Config, id string) (*Metri
 		return nil, errors.New("command required")
 	}
 	mp := &MetricPlugin{
-		ID:               fmt.Sprintf("plugin.metrics.%s", id),
+		ID:               fmt.Sprintf("plugin.mackerelmetrics.%s", id),
 		Command:          pc.Command,
 		Timeout:          pc.Timeout.Duration,
 		Interval:         pc.Interval.Duration,

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package sardine
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -205,14 +206,9 @@ func LoadConfig(path string, ch chan *cloudwatch.PutMetricDataInput, mch chan []
 	}
 
 	if c.APIKey != "" {
-		hostID, err := mc.DefaultConfig.LoadHostID()
-		if err != nil {
-			return c, errors.Wrap(err, "failed load host id")
+		if c.hostID, err = mc.DefaultConfig.LoadHostID(); err != nil {
+			log.Println("failed LoadHostID:", err)
 		}
-		if hostID != "" {
-			c.hostID = hostID
-		}
-
 		c.MackerelClient = mackerel.NewClient(c.APIKey)
 	}
 

--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 type Config struct {
-	APIKey                  string
 	Plugin                  map[string]map[string]*PluginConfig
 	CheckPlugins            map[string]*CheckPlugin
 	CloudWatchMetricPlugins map[string]*CloudWatchMetricPlugin

--- a/config.go
+++ b/config.go
@@ -206,6 +206,7 @@ func LoadConfig(path string, ch chan *cloudwatch.PutMetricDataInput, mch chan []
 	}
 
 	if c.APIKey != "" {
+		var err error
 		if c.hostID, err = mc.DefaultConfig.LoadHostID(); err != nil {
 			log.Println("failed LoadHostID:", err)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -24,7 +24,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 	if driver, ok := (mp.PluginDriver).(*sardine.CloudWatchDriver); ok {
 		if len(driver.Dimensions) != 2 {
-			t.Errorf("unexpected dimensions len expected:2 got:%d", len(mp.Dimensions))
+			t.Errorf("unexpected dimensions len expected:2 got:%d", len(driver.Dimensions))
 		}
 	} else {
 		t.Errorf("failed assertion: mp.PluginDriver expected *sardine.CloudWatchDriver")

--- a/config_test.go
+++ b/config_test.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/fujiwara/sardine"
-	mackerel "github.com/mackerelio/mackerel-client-go"
 )
 
 func TestLoadConfig(t *testing.T) {
 	c, err := sardine.LoadConfig(
 		"test/config.toml",
 		make(chan *cloudwatch.PutMetricDataInput, 1000),
-		make(chan []*mackerel.HostMetricValue, 1000),
 	)
 	if err != nil {
 		t.Error(err)

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	c, err := sardine.LoadConfig("test/config.toml", make(chan *cloudwatch.PutMetricDataInput, 1000), make(chan []*mackerel.HostMetricValue, 1000))
+	c, err := sardine.LoadConfig(
+		"test/config.toml",
+		make(chan *cloudwatch.PutMetricDataInput, 1000),
+		make(chan []*mackerel.HostMetricValue, 1000),
+	)
 	if err != nil {
 		t.Error(err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -12,9 +12,6 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if c.APIKey != "exampleKey" {
-		t.Errorf("unexpected apikey expected:exampleKey got:%s", c.APIKey)
-	}
 	cmp := c.CloudWatchMetricPlugins["memcached"]
 	if cmp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
 		t.Error("unexpected command", cmp.Command)

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,6 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 	mp := c.MetricPlugins["memcached"]
 	if mp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
 		t.Error("unexpected command", mp.Command)

--- a/config_test.go
+++ b/config_test.go
@@ -15,27 +15,23 @@ func TestLoadConfig(t *testing.T) {
 	if c.APIKey != "exampleKey" {
 		t.Errorf("unexpected apikey expected:exampleKey got:%s", c.APIKey)
 	}
-	mp := c.CloudWatchDriver["memcached"].MetricPlugin
-	if mp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
-		t.Error("unexpected command", mp.Command)
+	cmp := c.CloudWatchMetricPlugins["memcached"]
+	if cmp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
+		t.Error("unexpected command", cmp.Command)
 	}
-	if driver, ok := (mp.PluginDriver).(*sardine.CloudWatchDriver); ok {
-		if len(driver.Dimensions) != 2 {
-			t.Errorf("unexpected dimensions len expected:2 got:%d", len(driver.Dimensions))
-		}
-	} else {
-		t.Errorf("failed assertion: mp.PluginDriver expected *sardine.CloudWatchDriver")
+	if len(cmp.Dimensions) != 2 {
+		t.Errorf("unexpected dimensions len expected:2 got:%d", len(cmp.Dimensions))
 	}
-	if mp.Interval != 10*time.Second {
-		t.Errorf("unexpected interval expected:10s got:%s", mp.Interval)
+	if cmp.Interval != 10*time.Second {
+		t.Errorf("unexpected interval expected:10s got:%s", cmp.Interval)
 	}
-	if mp.Timeout != 15*time.Second {
-		t.Errorf("unexpected timeout expected:15s got:%s", mp.Timeout)
+	if cmp.Timeout != 15*time.Second {
+		t.Errorf("unexpected timeout expected:15s got:%s", cmp.Timeout)
 	}
 
 	cp := c.CheckPlugins["memcached"]
 	if cp.Command != "sh -c 'echo version | nc 127.0.0.1 11211'" {
-		t.Error("unexpected command", mp.Command)
+		t.Error("unexpected command", cp.Command)
 	}
 	if cp.Namespace != "memcached/check" {
 		t.Error("unexpected namespace", cp.Namespace)
@@ -50,16 +46,12 @@ func TestLoadConfig(t *testing.T) {
 		t.Errorf("unexpected timeout expected:1m got:%s", cp.Timeout)
 	}
 
-	msp := c.MackerelDriver["redis"].MetricPlugin
-	if msp.Command != "mackerel-plugin-redis" {
-		t.Error("unexpected command", msp.Command)
+	mmp := c.MackerelMetricPlugins["redis"]
+	if mmp.Command != "mackerel-plugin-redis" {
+		t.Error("unexpected command", mmp.Command)
 	}
-	if driver, ok := (msp.PluginDriver).(*sardine.MackerelDriver); ok {
-		if driver.Service != "production" {
-			t.Error("unexpected service", driver.Service)
-		}
-	} else {
-		t.Errorf("failed assertion: msp.PluginDriver expected *sardine.MackerelDriver")
+	if mmp.Service != "production" {
+		t.Error("unexpected service", mmp.Service)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -4,23 +4,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/fujiwara/sardine"
 )
 
 func TestLoadConfig(t *testing.T) {
-	c, err := sardine.LoadConfig(
-		"test/config.toml",
-		make(chan *cloudwatch.PutMetricDataInput, 1000),
-		make(chan sardine.ServiceMetric, 1000),
-	)
+	c, err := sardine.LoadConfig("test/config.toml")
 	if err != nil {
 		t.Error(err)
 	}
 	if c.APIKey != "exampleKey" {
 		t.Errorf("unexpected apikey expected:exampleKey got:%s", c.APIKey)
 	}
-	mp := c.MetricPlugins["memcached"]
+	mp := c.CloudWatchDriver["memcached"].MetricPlugin
 	if mp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
 		t.Error("unexpected command", mp.Command)
 	}
@@ -55,7 +50,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Errorf("unexpected timeout expected:1m got:%s", cp.Timeout)
 	}
 
-	msp := c.MetricPlugins["redis"]
+	msp := c.MackerelDriver["redis"].MetricPlugin
 	if msp.Command != "mackerel-plugin-redis" {
 		t.Error("unexpected command", msp.Command)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -12,6 +12,7 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	mp := c.MetricPlugins["memcached"]
 	if mp.Command != "mackerel-plugin-memcached --host 127.0.0.1 --port 11211" {
 		t.Error("unexpected command", mp.Command)

--- a/metrics.go
+++ b/metrics.go
@@ -41,14 +41,6 @@ func (m *Metric) NewMetricDatum(ds []*cloudwatch.Dimension) *cloudwatch.MetricDa
 	}
 }
 
-func (m *Metric) NewMackerelServiceMetric() *mackerel.MetricValue {
-	return &mackerel.MetricValue{
-		Name:  m.Name,
-		Value: m.Value,
-		Time:  m.Timestamp.Unix(),
-	}
-}
-
 type ServiceMetric struct {
 	Service      string
 	MetricValues []*mackerel.MetricValue
@@ -133,7 +125,11 @@ func (md *MackerelDriver) Run(ctx context.Context, ch chan ServiceMetric) {
 func (md *MackerelDriver) enqueue(metrics []*Metric) {
 	mv := []*mackerel.MetricValue{}
 	for _, m := range metrics {
-		mv = append(mv, m.NewMackerelServiceMetric())
+		mv = append(mv, &mackerel.MetricValue{
+			Name:  m.Name,
+			Value: m.Value,
+			Time:  m.Timestamp.Unix(),
+		})
 	}
 
 	md.Ch <- ServiceMetric{

--- a/metrics.go
+++ b/metrics.go
@@ -28,7 +28,6 @@ type MetricPlugin struct {
 	Command      string
 	Timeout      time.Duration
 	Interval     time.Duration
-	Dimensions   [][]*cloudwatch.Dimension
 	PluginDriver PluginDriver
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -92,7 +92,7 @@ func metricLineParser(b string) (*Metric, error) {
 	return &m, nil
 }
 
-func mackerelMetricParser(b string) (*Metric, error) {
+func mackerelMetlicLineParser(b string) (*Metric, error) {
 	cols := strings.SplitN(b, "\t", 3)
 	if len(cols) < 3 {
 		return nil, errors.New("invalid metric format. insufficient columns")

--- a/metrics.go
+++ b/metrics.go
@@ -126,10 +126,10 @@ type MackerelDriver struct {
 func (md *MackerelDriver) enqueue(metrics []*Metric) {
 	ms := []*mackerel.HostMetricValue{}
 	for _, metric := range metrics {
-		m := metric.NewMackerelMetric(me.HostID)
+		m := metric.NewMackerelMetric(md.HostID)
 		ms = append(ms, m)
 	}
-	me.Ch <- ms
+	md.Ch <- ms
 }
 
 func (md *MackerelDriver) parseMetricLine(b string) (*Metric, error) {

--- a/metrics.go
+++ b/metrics.go
@@ -65,8 +65,8 @@ type PluginDriver interface {
 }
 
 type CloudWatchDriver struct {
-	Ch         chan *cloudwatch.PutMetricDataInput
 	Dimensions [][]*cloudwatch.Dimension
+	Ch         chan *cloudwatch.PutMetricDataInput
 }
 
 func (cd *CloudWatchDriver) enqueue(metrics []*Metric) {
@@ -119,8 +119,8 @@ func (cd *CloudWatchDriver) parseMetricLine(b string) (*Metric, error) {
 }
 
 type MackerelDriver struct {
-	Ch     chan []*mackerel.HostMetricValue
 	HostID string
+	Ch     chan []*mackerel.HostMetricValue
 }
 
 func (md *MackerelDriver) enqueue(metrics []*Metric) {

--- a/sardine.go
+++ b/sardine.go
@@ -72,7 +72,7 @@ func putToCloudWatch(ctx context.Context, ch chan *cloudwatch.PutMetricDataInput
 }
 
 func putToMackerel(ctx context.Context, ch chan ServiceMetric) {
-	c := mackerel.NewClient(os.Getenv("MACKEREL_API_KEY"))
+	c := mackerel.NewClient(os.Getenv("MACKEREL_APIKEY"))
 
 	for {
 		select {

--- a/sardine.go
+++ b/sardine.go
@@ -35,10 +35,10 @@ func Run(configPath string) error {
 	go putToCloudWatch(ctx, ch)
 	go putToMackerel(ctx, conf, mch)
 
-	for _, cd := range conf.CloudWatchDriver {
+	for _, cd := range conf.CloudWatchMetricPlugins {
 		go cd.Run(ctx, ch)
 	}
-	for _, md := range conf.MackerelDriver {
+	for _, md := range conf.MackerelMetricPlugins {
 		go md.Run(ctx, mch)
 	}
 	for _, cp := range conf.CheckPlugins {

--- a/sardine.go
+++ b/sardine.go
@@ -34,7 +34,7 @@ func Run(configPath string) error {
 	wg.Add(1)
 
 	go putToCloudWatch(ctx, ch)
-	go putToMackerel(ctx, conf, mch)
+	go putToMackerel(ctx, mch)
 
 	for _, cmp := range conf.CloudWatchMetricPlugins {
 		go cmp.Run(ctx, ch)
@@ -71,7 +71,7 @@ func putToCloudWatch(ctx context.Context, ch chan *cloudwatch.PutMetricDataInput
 	}
 }
 
-func putToMackerel(ctx context.Context, conf *Config, ch chan ServiceMetric) {
+func putToMackerel(ctx context.Context, ch chan ServiceMetric) {
 	c := mackerel.NewClient(os.Getenv("MACKEREL_API_KEY"))
 
 	for {

--- a/sardine.go
+++ b/sardine.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/k0kubun/pp"
+	mackerel "github.com/mackerelio/mackerel-client-go"
 )
 
 var (
@@ -29,7 +31,9 @@ func Run(configPath string) error {
 	wg.Add(1)
 
 	ch := make(chan *cloudwatch.PutMetricDataInput, 1000)
+	mch := make(chan []*mackerel.HostMetricValue, 1000)
 	go putToCloudWatch(ctx, ch)
+	go putToMackerel(ctx, conf, mch)
 
 	for _, mp := range conf.MetricPlugins {
 		go mp.Run(ctx, ch)
@@ -37,6 +41,10 @@ func Run(configPath string) error {
 	}
 	for _, cp := range conf.CheckPlugins {
 		go cp.Run(ctx, ch)
+		time.Sleep(time.Second)
+	}
+	for _, mp := range conf.MackerelMetricPlugins {
+		go mp.RunForMackerel(ctx, mch)
 		time.Sleep(time.Second)
 	}
 
@@ -59,6 +67,26 @@ func putToCloudWatch(ctx context.Context, ch chan *cloudwatch.PutMetricDataInput
 			_, err := svc.PutMetricDataWithContext(ctx, in, request.WithResponseReadTimeout(30*time.Second))
 			if err != nil {
 				log.Println("putMetricData failed:", err)
+			}
+		}
+	}
+}
+
+func putToMackerel(ctx context.Context, c *Config, ch chan []*mackerel.HostMetricValue) {
+	client := mackerel.NewClient(c.APIKey)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case in := <-ch:
+			if Debug {
+				log.Println("put")
+				pp.Println(in)
+			}
+			err := client.PostHostMetricValues(in)
+			if err != nil {
+				log.Println("putToMackerel failed:", err)
 			}
 		}
 	}

--- a/sardine.go
+++ b/sardine.go
@@ -36,10 +36,10 @@ func Run(configPath string) error {
 	go putToMackerel(ctx, conf, mch)
 
 	for _, cmp := range conf.CloudWatchMetricPlugins {
-		go cd.Run(ctx, ch)
+		go cmp.Run(ctx, ch)
 	}
 	for _, mmp := range conf.MackerelMetricPlugins {
-		go md.Run(ctx, mch)
+		go mmp.Run(ctx, mch)
 	}
 	for _, cp := range conf.CheckPlugins {
 		go cp.Run(ctx, ch)

--- a/sardine.go
+++ b/sardine.go
@@ -3,6 +3,7 @@ package sardine
 import (
 	"context"
 	"log"
+	"os"
 	"sync"
 	"time"
 
@@ -71,7 +72,7 @@ func putToCloudWatch(ctx context.Context, ch chan *cloudwatch.PutMetricDataInput
 }
 
 func putToMackerel(ctx context.Context, conf *Config, ch chan ServiceMetric) {
-	c := mackerel.NewClient(conf.APIKey)
+	c := mackerel.NewClient(os.Getenv("MACKEREL_API_KEY"))
 
 	for {
 		select {

--- a/sardine.go
+++ b/sardine.go
@@ -35,10 +35,10 @@ func Run(configPath string) error {
 	go putToCloudWatch(ctx, ch)
 	go putToMackerel(ctx, conf, mch)
 
-	for _, cd := range conf.CloudWatchMetricPlugins {
+	for _, cmp := range conf.CloudWatchMetricPlugins {
 		go cd.Run(ctx, ch)
 	}
-	for _, md := range conf.MackerelMetricPlugins {
+	for _, mmp := range conf.MackerelMetricPlugins {
 		go md.Run(ctx, mch)
 	}
 	for _, cp := range conf.CheckPlugins {

--- a/sardine.go
+++ b/sardine.go
@@ -22,7 +22,6 @@ var (
 func Run(configPath string) error {
 	ch := make(chan *cloudwatch.PutMetricDataInput, 1000)
 	mch := make(chan []*mackerel.HostMetricValue, 1000)
-
 	conf, err := LoadConfig(configPath, ch, mch)
 	if err != nil {
 		return err

--- a/test/config.toml
+++ b/test/config.toml
@@ -10,6 +10,7 @@ interval   = "10s"
 namespace = "memcached/check"
 command   = "sh -c 'echo version | nc 127.0.0.1 {{ env `MEMCACHED_PORT` `11211` }}'"
 
-[plugin.servicemetrics.redis]
-command    = 'mackerel-plugin-redis'
-service    = "production"
+[plugin.metrics.redis]
+command     = 'mackerel-plugin-redis'
+destination = "mackerel"
+service     = "production"

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,3 +1,5 @@
+apikey = 'exampleKey'
+
 [plugin.metrics.memcached]
 command    = 'mackerel-plugin-memcached --host 127.0.0.1 --port {{ env "MEMCACHED_PORT" "11211" }}'
 dimensions = ["Instance-Id=i-12345678", "Host=127.0.0.1"]
@@ -7,3 +9,7 @@ interval   = "10s"
 [plugin.check.memcached]
 namespace = "memcached/check"
 command   = "sh -c 'echo version | nc 127.0.0.1 {{ env `MEMCACHED_PORT` `11211` }}'"
+
+[plugin.servicemetrics.redis]
+command    = 'mackerel-plugin-redis'
+service    = "production"

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,5 +1,3 @@
-apikey = 'exampleKey'
-
 [plugin.metrics.memcached]
 command    = 'mackerel-plugin-memcached --host 127.0.0.1 --port {{ env "MEMCACHED_PORT" "11211" }}'
 dimensions = ["Instance-Id=i-12345678", "Host=127.0.0.1"]


### PR DESCRIPTION
Added function to send metrics directly to mackerel.

```
[plugin.mackerelmetrics.metrics]
command           = 'mackerel-plugin-memcached --host 127.0.0.1 --port 11211'
custom_identifier = 'node01.memcached.example.com'
```