### PR TITLE
split MetricDatum 20/PutMetricDataInput.

### DIFF
--- a/check.go
+++ b/check.go
@@ -57,9 +57,20 @@ func (cp *CheckPlugin) Run(ctx context.Context, ch chan *cloudwatch.PutMetricDat
 		// no dimension metric
 		md = append(md, res.NewMetricDatum(nil, now))
 
-		ch <- &cloudwatch.PutMetricDataInput{
-			Namespace:  aws.String(cp.Namespace),
-			MetricData: md,
+		// split MetricDatum/20
+		for i := 0; i <= len(md)/maxMetricDatum; i++ {
+			first := i * maxMetricDatum
+			last := first + maxMetricDatum
+			if last > len(md) {
+				last = len(md)
+			}
+			if len(md[first:last]) == 0 {
+				break
+			}
+			ch <- &cloudwatch.PutMetricDataInput{
+				Namespace:  aws.String(cp.Namespace),
+				MetricData: md[first:last],
+			}
 		}
 
 		select {

--- a/sardine.go
+++ b/sardine.go
@@ -18,6 +18,8 @@ var (
 	Debug                 = false
 	DefaultInterval       = time.Minute
 	DefaultCommandTimeout = time.Minute
+
+	maxMetricDatum = 20
 )
 
 func Run(configPath string) error {


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html

> 20/PutMetricData request. A MetricDatum object can contain a single value or a StatisticSet object representing many values. This limit cannot be changed.